### PR TITLE
Multiarch build on 64-bit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,25 @@
-name = libframetime.so
+ARCH := $(shell getconf LONG_BIT)
+name32 = libframetime32.so
+name64 = libframetime64.so
 src = $(wildcard *.c)
-
+ 
 .PHONY: all clean
-
-CFLAGS ?= -O3
-CFLAGS += -Wall -Wextra
-
+ 
+CFLAGS32 ?= -O3 -Wall -Wextra -m32
+CFLAGS64 ?= -O3 -Wall -Wextra
+ 
 LDFLAGS += -Wl,-O1
-
+ 
 all: $(src)
-	$(CC) -o $(name) -shared $(CFLAGS) $(LDFLAGS) $(src) -ldl -fPIC
-	strip --strip-unneeded $(name)
-
+    ifeq ($(ARCH),64)
+        $(CC) -o $(name64) -shared $(CFLAGS64) $(LDFLAGS) $(src) -ldl -fPIC
+        strip --strip-unneeded $(name64)
+        $(CC) -o $(name32) -shared $(CFLAGS32) $(LDFLAGS) $(src) -ldl -fPIC
+        strip --strip-unneeded $(name32)
+    else
+        $(CC) -o $(name32) -shared $(CFLAGS32) $(LDFLAGS) $(src) -ldl -fPIC
+        strip --strip-unneeded $(name32)
+    endif
+ 
 clean:
-	rm -f $(name) *.o
+        rm -f $(name32) $(name64) *.o

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -13,13 +13,19 @@ your CFLAGS.
 Usage
 -----
 
+On 32-bit systems:
 ----
-LD_PRELOAD=path/to/libframetime.so dota2
+LD_PRELOAD=path/to/libframetime32.so dota2
+----
+
+On 64-bit systems add multiple libs to preload and let the application pick one that works out for its compiled architecture:
+----
+LD_PRELOAD="path/to/libframetime64.so:path/to/libframetime32.so" dota2
 ----
 
 Or with a custom output file:
 ----
-LIBFRAMETIME_FILE=/tmp/dota2.frametime LD_PRELOAD=path/to/libframetime.so dota2
+LIBFRAMETIME_FILE=/tmp/dota2.frametime LD_PRELOAD=path/to/libframetime<arch>.so dota2
 ----
 
 The accompanying awk script can be used to calculate the usual stats:


### PR DESCRIPTION
On multi-arch 64 bit Linux one might have 32 bit applications too, so the lib needs to be compiled for 32 bit also.
Generate both .so files and preload them both and the application will pick the right one.
